### PR TITLE
WIP: Fixups

### DIFF
--- a/js/karma_get_defaults.js
+++ b/js/karma_get_defaults.js
@@ -2,12 +2,11 @@ const path = require('path')
 
 const systematicConfig = require('./config')
 
-// FIXME(vperron): We use 'default' config here, not the application one. Fix it.
-const webpackGetDefaults = require('./webpack_get_defaults')
 
+module.exports = function (basePath, _webpackConfig) {
 
-module.exports = function (basePath) {
-  const webpackConfig = webpackGetDefaults(basePath)
+  const webpackConfig = _webpackConfig || require('./webpack_get_defaults')(basePath)
+
   // fast rebuild, see https://webpack.github.io/docs/configuration.html#devtool
   // complete source maps are very slow
   webpackConfig.devtool = 'cheap-module-source-map'

--- a/js/karma_get_defaults.js
+++ b/js/karma_get_defaults.js
@@ -6,16 +6,17 @@ const systematicConfig = require('./config')
 const webpackGetDefaults = require('./webpack_get_defaults')
 
 
-module.exports = function(basePath) {
+module.exports = function (basePath) {
   const webpackConfig = webpackGetDefaults(basePath)
   // fast rebuild, see https://webpack.github.io/docs/configuration.html#devtool
   // complete source maps are very slow
   webpackConfig.devtool = 'cheap-module-source-map'
   webpackConfig.entry = {}  // Reset the webpack entry point, test files are added separatly by karma-webpack
+  webpackConfig.externals = []  // Keep all the dependencies during the tests
 
   const testFiles = path.join(basePath, systematicConfig.test.file_pattern)
 
-  const karmaConfig =  {
+  const karmaConfig = {
     basePath: basePath,
     autoWatch: true, // Without this _in the config file_, plugins do not reload automatically
     browserNoActivityTimeout: 100000, // in ms, 100 seconds

--- a/js/webpack_get_defaults.js
+++ b/js/webpack_get_defaults.js
@@ -106,9 +106,6 @@ module.exports = function (basePath) {
       root: [path.resolve(basePath)],
     },
     module: {
-      preLoaders: [
-        { test: /\.js$/, loader: 'source-map-loader' },
-      ],
       loaders: [
         {
           test: /\.js/,

--- a/js/webpack_get_defaults.js
+++ b/js/webpack_get_defaults.js
@@ -1,5 +1,7 @@
 /* Systematic's webpack base config file */
 
+'use strict'
+
 const path = require('path')
 
 // TODO(vperron): Terrible to require this for the 5 lines this plugin is.
@@ -50,6 +52,15 @@ function buildPublicPath () {
   else return `http://127.0.0.1:${config.serve.port}/`
 }
 
+function getDependencies () {
+  let packageJson
+  try {
+    packageJson = require('package.json')
+  } catch (e) {
+    return []
+  }
+  return Object.keys(packageJson.dependencies)
+}
 
 module.exports = function (basePath) {
 
@@ -86,6 +97,7 @@ module.exports = function (basePath) {
       publicPath: buildPublicPath(), // Prefix for all the static urls
       libraryTarget: config.build.type === enums.buildTypes.LIBRARY ? 'umd' : 'var',
     },
+    externals: config.build.type === enums.buildTypes.LIBRARY ? getDependencies() : [],
     resolve: {
       root: [path.resolve(basePath)],
     },

--- a/js/webpack_get_defaults.js
+++ b/js/webpack_get_defaults.js
@@ -2,6 +2,7 @@
 
 'use strict'
 
+const fs = require('fs')
 const path = require('path')
 
 // TODO(vperron): Terrible to require this for the 5 lines this plugin is.
@@ -80,11 +81,14 @@ module.exports = function (basePath) {
     })
   }
   if (config.build.type === enums.buildTypes.APPLICATION) {
-    plugins.push(new HtmlPlugin({
-      inject: true,
-      filename: 'index.html',
-      template: path.join(config.build.src_dir, 'index.html'),
-    }))
+    const indexHtmlPath = path.join(config.build.src_dir, 'index.html')
+    if (fs.existsSync(indexHtmlPath)) {
+      plugins.push(new HtmlPlugin({
+        inject: true,
+        filename: 'index.html',
+        template: indexHtmlPath,
+      }))
+    }
   }
 
   return {

--- a/js/webpack_get_defaults.js
+++ b/js/webpack_get_defaults.js
@@ -5,14 +5,12 @@ const path = require('path')
 // TODO(vperron): Terrible to require this for the 5 lines this plugin is.
 const combineLoaders = require('webpack-combine-loaders')
 const HtmlPlugin = require('html-webpack-plugin')
-const OmitTildeWebpackPlugin = require('omit-tilde-webpack-plugin')
 
 const config = require('./config')
 const enums = require('./config_choices')
-const plugins = [
-  new OmitTildeWebpackPlugin({include: 'package.json'}),
-]
 
+/* Global plugins collection, will be filled according to the profile */
+const plugins = []
 
 /* Pre-configure loaders */
 const jsLoaders = [{

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -167,7 +167,7 @@ endif
 /tmp/template.pot: $(GETTEXT_JS_SOURCES) $(GETTEXT_HTML_SOURCES)
 	@echo "$(ECHOPREFIX) extracting translations $(ECHOSUFFIX)"
 	mkdir -p $(dir $@)
-	gettext-extract --output $@ $(GETTEXT_HTML_SOURCES)
+	gettext-extract --quiet --output $@ $(GETTEXT_HTML_SOURCES)
 	xgettext --language=JavaScript --keyword=i18n --from-code=utf-8 \
 		--sort-output --join-existing --no-wrap --package-name=$(PACKAGE_NAME) \
 		--package-version=$(shell node -e "console.log(require('./package.json').version);") \

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "phantomjs-prebuilt": "2.1.7",
     "postcss-loader": "0.8.2",
     "sass-loader": "3.2.0",
-    "source-map-loader": "0.1.5",
     "standard": "6.0.8",
     "style-loader": "0.13.1",
     "url-loader": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "babel-polyfill": "6.7.4",
     "babel-preset-es2015": "6.6.0",
     "css-loader": "0.23.1",
-    "easygettext": "1.0.3",
+    "easygettext": "1.1.1",
     "eslint": "2.7.0",
     "file-loader": "0.8.5",
     "html-loader": "0.4.3",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "ng-annotate-loader": "0.1.0",
     "ngtemplate-loader": "1.3.1",
     "node-sass": "3.4.2",
-    "omit-tilde-webpack-plugin": "0.1.1",
     "phantomjs-prebuilt": "2.1.7",
     "postcss-loader": "0.8.2",
     "sass-loader": "3.2.0",


### PR DESCRIPTION
Encore une PR avec des fixups.

- [x] Retirer le omit tilde plugin, assez inutile et qui ne fonctionne plus pour une raison inconnue ?
- [ ] Retirer les dependances (angular, etc) lorsque c'est une lib
- [ ] Gérer les fichiers de locales de momentJS.

TODOs éventuels à discuter ! @stephane @raphael-boucher 

- [ ] Dégager les webpack.conf.js et karma.conf.js du projet cible, systematic.ini devrait suffire !
- [ ] Problème bluetils-js: lorsqu'un test fail, on reporte test_utils.js comme lieu de fail, qque soit le test.
- [ ] Separate CSS and JS output ?
- [ ] Revoir rapidement les shims (moment locales, jquery angular) dans bluetils JS

La question à 1000 euros est...

**COMPILE-T-ON LES LIBRARIES ?**

Jusqu'à aujourd'hui, blease-js n'avait pas la capacité de compiler des bibliothèques JS. Bluetils-js était donc livré "tel quel": uniquement le code source.

Force est de constater que dans le monde Javascript, les deux alternatives existent.
AngularJS par exemple est livré comme un fichier JS ES5 compilé, prêt à l'mploi (disons, **standalone**)

JQuery, idem. 

MomentJS est livré avec des fichiers compilés ET ses sources.

React est livré avec des choses compilées complètes et d'autres bouts d code compilés en ES5 mais plus modulaires, au choix.

Font-Awesome est livré avec soit la source SASS, soit la source LESS, soit du compilé CSS, ainsi que les assets.

Etc etc.

Bref, tout est plus ou moins compilé en général, dans les paquets Node livrés sur le registry.

----

Aujourd'hui, bluetils-js est "pensé" pour ne pas être compilé. Blease-JS n'en était tout simplement pas capable (pas de transpilation péalable possible, pour des raisons compliquées) ; du coup, la distribution etait simple: c'est un paquet testé et versionné contenant du code source.

Ce code source est soit de l'ES6, soit du SASS, pour caricaturer. On ne se posait donc pas la question; dans une application, on require bluetils-js et on l'utilise directement depuis ses sources.

Malheureusement le fonctionnement de systematic ne va pas dans ce sens. On ne veut pas transpiler quelque chose qui est dans node_modules, de manière assez évidente. On voudrait importer du code compilé, comme tout bibliothèque normale, et l'utiliser dans nos applications.

Cela se fait assez facilement pour l'ES6: on build le bundle de bluetils-js en spécifiant que les dépendances doivent être "external". All good.

Mais le problème est autrement plus compliqué pour les "assets": le SASS partagé, les images, etc.
Le feeling serait de déplacer tout cela dans **cassets** de toute manière; et de n'autoriser dans bluetils-js que du sass "minimal", des templates internes, des images internes, etc. Mais pas d'importer tout l'univers depuis un `@import bootstrap-full.sass`, pour caricaturer.

Mais le problème se déplace: faut-il compiler `cassets` ou non ? Mon feeling me dirait que non. On garderait `cassets` comme une bibliothèque partagée d'images, de polices de caractères, de variables SASS partagées, qui ne serait pas buildée.

Seriez-vous OK avec ces approches ?

Auquel cas, on aurait à:
* Retirer les composantes "cassets" de bluetils-js (couleurs, icônes, etc: les choses qui ne se "compilent" pas avec systematic)
* Retirer tous les appels "abusifs" en SASS de bluetils-js (fini les @import font-awesome depuis des sous-libs) et conserver le SASS le plus minimal possible, éventuellement en important des variables depuis cassets, version figée.
* Builder chaque version future de bluetils-js vers l'ES5 et le CSS, les deux fichiers de sortie devant être minimaux.
* Vérifier que tout se passe bien dans les applis cibles; il faut qu'elles cessent de considérer que bluetils-js est un "ensemble de fichiers intermédaires" mais plutot une véritable bibliothèque. Y a du boulot :)