### PR TITLE
Configurable public path (URL)

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -10,6 +10,7 @@ _.defaultsDeep(systematic, {
   build: {
     src_dir: 'src',
     output_dir: 'dist',
+    public_path: '/',
   },
   serve: {
     port: 8080,

--- a/js/webpack_get_defaults.js
+++ b/js/webpack_get_defaults.js
@@ -49,7 +49,7 @@ if (PRODUCTION_MODE) {
 }
 
 function buildPublicPath () {
-  if (PRODUCTION_MODE) return '/'
+  if (PRODUCTION_MODE) return `${config.build.public_path}`
   else return `http://127.0.0.1:${config.serve.port}/`
 }
 

--- a/systematic.example.ini
+++ b/systematic.example.ini
@@ -7,6 +7,8 @@ type = library
 output_dir = dist
 ; The relative path to the source dir
 src_dir = src
+; The public path of the application (eg. '/app/')
+public_path = '/'
 
 [serve]
 ; The network port to access the local website, if it's an app


### PR DESCRIPTION
Add new setting to set up the public path of the application (when hosted in a distinct directory).