### PR TITLE
Add npgettext in the keyword list of xgettext

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -168,7 +168,7 @@ endif
 	@echo "$(ECHOPREFIX) extracting translations $(ECHOSUFFIX)"
 	mkdir -p $(dir $@)
 	gettext-extract --quiet $(GETTEXTEXTRACT_OPTIONS) --output $@ $(GETTEXT_HTML_SOURCES)
-	xgettext --language=JavaScript --keyword=i18n --from-code=utf-8 \
+	xgettext --language=JavaScript --keyword=i18n --keyword=npgettext:1c,2,3 --from-code=utf-8 \
 		--sort-output --join-existing --no-wrap --package-name=$(PACKAGE_NAME) \
 		--package-version=$(shell node -e "console.log(require('./package.json').version);") \
 		--copyright=POLYCONSEIL --output $@ $(GETTEXT_JS_SOURCES)


### PR DESCRIPTION
`npgettext` is not in the **JavaScript** default keyword list of `xgettext`, see [`‘--keyword[=keywordspec]’`](https://www.gnu.org/savannah-checkouts/gnu/gettext/manual/html_node/xgettext-Invocation.html#Language-specific-options).

Note that Django [does the same thing](https://github.com/django/django/blob/8db889eaf7dce0cb715b075be32047c1b1b316da/django/core/management/commands/makemessages.py#L527).