### PR TITLE
Stop extracting strings on translations.json build

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -196,6 +196,6 @@ endif
 		msgattrib --no-wrap --no-location --no-obsolete -o $$PO_FILE $$PO_FILE; \
 	done;
 
-$(OUTPUT_DIR)/translations.json: /tmp/template.pot
+$(OUTPUT_DIR)/translations.json:
 	mkdir -p $(OUTPUT_DIR)
 	gettext-compile --output $@ $(LOCALE_FILES)


### PR DESCRIPTION
Translations strings should be extracted only when explicitly asked with `make makemessages`.
At the moment, they are extracted every time the `translations.json` file is generated, which can cause translation losses during development and unnecessary diffs in commits.  