### PR TITLE
Add support for cssnext and @import in postCSS.

### DIFF
--- a/js/webpack_get_defaults.js
+++ b/js/webpack_get_defaults.js
@@ -51,7 +51,6 @@ if (PRODUCTION_MODE) {
   sassLoaders.forEach(function (loader) { loader.query.sourceMap = true })
 }
 
-
 switch(config.build.type) {
   case enums.buildTypes.APPLICATION:
   case enums.buildTypes.COMPONENT:
@@ -178,6 +177,14 @@ module.exports = function (basePath) {
     devtool: 'source-map',  // A source map will be emitted.
     sassLoader: {
       includePaths: [path.join(basePath, 'node_modules')],
+    },
+    postcss: function () {
+      return [
+        require('postcss-cssnext'),
+        require('postcss-import')({  // This plugin enables @import rule in CSS files.
+          path: [basePath],  // Use the same path for CSS and JS imports
+        }),
+      ]
     },
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "ngtemplate-loader": "1.3.1",
     "node-sass": "3.7.0",
     "phantomjs-prebuilt": "2.1.7",
+    "postcss-cssnext": "^2.9.0",
+    "postcss-import": "^9.0.0",
     "postcss-loader": "0.9.1",
     "sass-loader": "3.2.0",
     "standard": "7.1.2",


### PR DESCRIPTION
Enables rich stuff like

```css
@import 'src/variables.css'

.myclass {
  &.subclass {
    color: var(--color-blue);
  }
}
```