### PR TITLE
WIP ini2js: fix merging configs with same section

### DIFF
--- a/bin/ini2js.js
+++ b/bin/ini2js.js
@@ -390,7 +390,12 @@ var namespace = argv.namespace || '__SETTINGS__';
 var config = {};
 filenames.forEach(function(filename) {
   var parsed = iniDecode(fs.readFileSync(filename, 'utf-8'));
-  for (var i in parsed) { config[i] = parsed[i]; }
+  for (var section in parsed) {
+    config[section] = config[section] || {};
+    for (var key in parsed[section]) {
+      config[section][key] = parsed[section][key];
+    }
+  }
 });
 
 console.log(util.format('window.%s = %s;', namespace, JSON.stringify(config)));

--- a/sample/empty.ini
+++ b/sample/empty.ini
@@ -1,0 +1,2 @@
+# Empty section to test merging of ini2js
+[build]


### PR DESCRIPTION
A new section, e.g. [app], would overwrite the same section loaded from
the previous file.

Fixed by adding a level of iteration in the items of a section, but I
couldn't write a test for it. Karma doesn't like the shebang line.