### PR TITLE
add a new option to disable hashing of the bundle name

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ The file structure expected for your application or library.
   ; Optional, default is blank
   ; The locales to generate translation files
   locales = en_US en_GB
+  ; Optional, default is true
+  ; Whether to hash the generated bundle.js (relevant only for type = application)
+  enableFileNameHashing = false
 
   [serve]
   ; Interface to listen

--- a/js/config.js
+++ b/js/config.js
@@ -11,6 +11,7 @@ _.defaultsDeep(systematic, {
     src_dir: 'src',
     output_dir: 'dist',
     public_path: '/',
+    enable_filename_hashing: true,
   },
   serve: {
     host: '127.0.0.1',

--- a/js/webpack_get_defaults.js
+++ b/js/webpack_get_defaults.js
@@ -68,7 +68,7 @@ function getOutputFileName () {
   let name = 'index.js'
   if (config.build.type === enums.buildTypes.APPLICATION) {
     name = 'bundle.js'
-    if (PRODUCTION_MODE) {
+    if (PRODUCTION_MODE && config.build.enable_filename_hashing) {
       name = `${name}.[hash].js`
     }
   }


### PR DESCRIPTION
Some applications may be included in a web page by a web framework (e.g.
django) which is responsible for handling the hashing of its static assets.
This option enables to disable hashing for such purposes.