### PR TITLE
main.mk: delete temp makemessages file

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -191,6 +191,7 @@ endif
 		[ -f $$PO_FILE ] && msgmerge --lang=$$lang --sort-output --update $$PO_FILE $@ || msginit --no-translator --locale=$$lang --input=$@ -o $$PO_FILE; \
 		msgattrib --no-wrap --no-location --no-obsolete -o $$PO_FILE $$PO_FILE; \
 	done;
+	rm $@
 
 $(OUTPUT_DIR)/translations.json: $(LOCALE_FILES)
 	mkdir -p $(dir $@)


### PR DESCRIPTION
the presence of this temp file (not temporary anymore then) causes
command makemessages not to do anything, unless using `make clean` beforehand