### PR TITLE
mk: don't systematically open the new instance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Next version (not yet released)
+-------------------------------
+
+- Stopped opening a new tab on "make serve".
+
 Version 1.3.0
 -------------
 - devtool: Use cheap-module-source-map as it's the only one that works. (by Victor Perron 14 hours ago)

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -154,7 +154,7 @@ settings: $(OUTPUT_DIR)/app.settings.js
 
 serve: prepare
 	mkdir -p $(OUTPUT_DIR)
-	webpack-dev-server --content-base $(OUTPUT_DIR) --hot --inline --open \
+	webpack-dev-server --content-base $(OUTPUT_DIR) --hot --inline \
 		--port $(SERVE_PORT) --host $(SERVE_HOST) \
 		--colors --bail --progress --output-pathinfo
 


### PR DESCRIPTION
You may not even use the given host because you're behind a proxy
(integration tests) or you already opened it, or you don't even want
to open it, just run automated tests elsewhere.