### PR TITLE
Some Vue-related fixes.

### DIFF
--- a/js/webpack_get_defaults.js
+++ b/js/webpack_get_defaults.js
@@ -5,8 +5,6 @@
 const fs = require('fs')
 const path = require('path')
 
-const webpack = require('webpack')
-
 const HtmlPlugin = require('html-webpack-plugin')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 
@@ -98,12 +96,12 @@ function configureHTMLPlugin () {
     }
     return new HtmlPlugin(htmlPluginProperties)
   }
-  throw "file " + indexHtmlPath + " not found"
+  throw new Error('file ' + indexHtmlPath + ' not found')
 }
 
 function buildBabelPresets (profile) {
   const presets = [
-    ['es2015', {'modules': false }],
+    ['es2015', {'modules': false}],
     'es2016',
     'es2017',
     'stage-3',  // needed for object spread operator "..."
@@ -123,9 +121,9 @@ function getDevtool () {
 
 function getBabelPlugins () {
   const plugins = [
-    require('babel-plugin-transform-strict-mode'),
-    [require('babel-plugin-transform-runtime'), {polyfill: false}],
-    require('babel-plugin-transform-class-properties'),
+    'transform-strict-mode',
+    ['transform-runtime', {polyfill: false}],
+    'transform-class-properties',
   ]
 
   if (config.build.type === enums.buildTypes.APPLICATION && config.build.profile === 'angular') {
@@ -150,7 +148,7 @@ module.exports = function (basePath) {
       presets: buildBabelPresets(config.build.profile),
       plugins: getBabelPlugins(),
       comments: false,
-    }
+    },
   }]
 
   const cssLoader = {
@@ -234,10 +232,11 @@ module.exports = function (basePath) {
           loader: 'vue-loader',
           options: {
             loaders: {
+              js: jsLoaders,
               css: ['vue-style-loader', cssLoader],
               postcss: ['vue-style-loader', cssLoader, postCssLoader],
-            }
-          }
+            },
+          },
         },
         {
           test: /\.css/,

--- a/js/webpack_get_defaults.js
+++ b/js/webpack_get_defaults.js
@@ -255,5 +255,8 @@ module.exports = function (basePath) {
     },
     plugins: plugins,
     devtool: getDevtool(),
+    devServer: {
+      disableHostCheck: true,  // since webpack 2.4.3, a host check is present, remove it.
+    }
   }
 }

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -72,7 +72,7 @@ endif
 
 # Other variables
 
-ESLINTRC ?= ./$(SYSTEMATIC_PATH)/.eslintrc
+ESLINTRC ?= ./$(SYSTEMATIC_PATH).eslintrc
 ESLINTOPTIONS ?=
 
 LOCALES ?= $(call readini,$(CONF_INI),build,locales)

--- a/mk/vue.mk
+++ b/mk/vue.mk
@@ -1,5 +1,5 @@
-GETTEXT_HTML_SOURCES ?= $(shell find $(SRC_DIR) -name '*.jade' -o -name '*.html' -o -name '*.vue' 2> /dev/null)
-GETTEXT_JS_SOURCES   ?= $(shell find $(SRC_DIR) -name '*.js' -o -name '*.vue')
+GETTEXT_HTML_SOURCES := $(shell find $(SRC_DIR) -name '*.jade' -o -name '*.html' -o -name '*.vue' 2> /dev/null)
+GETTEXT_JS_SOURCES := $(shell find $(SRC_DIR) -name '*.js' -o -name '*.vue')
 
 GETTEXTEXTRACT_OPTIONS := --attribute='v-translate'
-ESLINTOPTIONS := --ext='.js' --ext='.vue' --plugin='html'
+ESLINTOPTIONS := --ext .js,.vue --plugin html


### PR DESCRIPTION
- use jsloaders within Vue files to allow for ES6 inside them.
  (this disallows the use of require() inside the jsloaders, but
  the string version is recommanded anyway, see babeljs.com)
- slightly make the syntax check command less verbose