### PR TITLE
webpack config: preserve css variables with css next

### DIFF
--- a/js/webpack_get_defaults.js
+++ b/js/webpack_get_defaults.js
@@ -165,7 +165,13 @@ module.exports = function (basePath) {
           require('postcss-import')({  // This plugin enables @import rule in CSS files.
             path: [basePath],  // Use the same path for CSS and JS imports
           }),
-          require('postcss-cssnext'),
+          require('postcss-cssnext')({
+            features: {
+              customProperties: {
+                preserve: true,
+              },
+            },
+          }),
         ]
       },
     },


### PR DESCRIPTION
see https://github.com/postcss/postcss-custom-properties#preserve

This option preserves css variables definitions. This is useful if you
want to keep the dynamic aspect of css variables. One use case is
variable overriding when including a component inside a web page.

```css
/* input */
:root {
  --my-var: 16px;
}

.myClass {
  margin-top: var(--my-var);
}

/* output with preserve = true */
:root {
  --my-var: 16px;
}

.myClass {
  margin-top: 16px;  /* for compatibility with old browsers (IE11) */
  margin-top: var(--my-var);
}

/* output with preserve = false */
.myClass {
  margin-top: 16px;
}
```