### PR TITLE
For discussion: remove hard source webpack plugin ?

### DIFF
--- a/js/karma_get_defaults.js
+++ b/js/karma_get_defaults.js
@@ -1,7 +1,5 @@
 const path = require('path')
 
-const HardSourceWebpackPlugin = require('hard-source-webpack-plugin')
-
 const systematicConfig = require('./config')
 
 if (!process.env.CHROME_BIN) {
@@ -15,7 +13,6 @@ module.exports = function (basePath, _webpackConfig) {
   webpackConfig.devtool = 'eval'  // fastest source map ever
   webpackConfig.entry = function(){return {}}  // Reset the webpack entry point, test files are added separatly by karma-webpack
   webpackConfig.externals = []  // Keep all the dependencies during the tests
-  webpackConfig.plugins.push(new HardSourceWebpackPlugin())
 
   const testFiles = path.join(basePath, systematicConfig.test.file_pattern)
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "eslint-plugin-html": "3.2.2",
     "extract-text-webpack-plugin": "^3.0.2",
     "file-loader": "1.1.5",
-    "hard-source-webpack-plugin": "^0.4.11",
     "html-loader": "0.5.1",
     "html-webpack-plugin": "2.30.1",
     "http-server": "0.10.0",


### PR DESCRIPTION
When running **several times in a row**(*) `make test`, this webpack plugins appears to provoke the following errors:
```
14 11 2017 10:02:33.987:INFO [karma]: Karma v1.7.1 server started at http://0.0.0.0:9876/
14 11 2017 10:02:33.989:INFO [launcher]: Launching browser ChromeHeadless with unlimited concurrency
14 11 2017 10:02:34.006:INFO [launcher]: Starting browser ChromeHeadless
14 11 2017 10:02:34.320:INFO [HeadlessChrome 0.0.0 (Linux 0.0.0)]: Connected on socket 7cfdxPIj-lVaIP5OAAAA with id 80989099
HeadlessChrome 0.0.0 (Linux 0.0.0) ERROR
 Script error.
```
or
```
    ✖ loadFileList
      HeadlessChrome 0.0.0 (Linux 0.0.0)

    Error: Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL.
```
(*) These errors disappear when clearing module's cache: `rm -rf node_modules/.cache/hard-source/`. Once they reappear, they "stay".

Considering the small speed improvement it provides (https://github.com/Polyconseil/systematic/pull/67 stated 2s, which is the order of magnitude I noticed on my project) and the numerous issues it can cause (see https://github.com/mzgoddard/hard-source-webpack-plugin/issues) I'd be in favour not to use it before it is a bit drier.
