### PR TITLE
webpack: use DefinePlugin to pass NODE_ENV to Uglify

### DIFF
--- a/js/webpack_get_defaults.js
+++ b/js/webpack_get_defaults.js
@@ -5,6 +5,8 @@
 const fs = require('fs')
 const path = require('path')
 
+const webpack = require('webpack')
+
 const HtmlPlugin = require('html-webpack-plugin')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const UglifyPlugin = require('uglifyjs-webpack-plugin')
@@ -240,6 +242,7 @@ module.exports = function (basePath) {
         use: loaders,
       })
     }
+    plugins.push(new webpack.DefinePlugin({'process.env': {NODE_ENV: '"production"'}}))
   }
 
   switch (config.build.type) {


### PR DESCRIPTION
This commit fixes a regression introduced by cfaecf1e5c8955a197.

According to the webpack doc:

-p is equivalent to --optimize-minimize --define process.env.NODE_ENV="production"

Removing the -p had the effect of preventing UglifyJS from removing Vuejs
dev mode logging. We for example had the following log in our production
bundles:

    You are running Vue in development mode.
    Make sure to turn on production mode when deploying for production.
    See more tips at https://vuejs.org/guide/deployment.html

The --define process.env.NODE_ENV="production" can be replaced by this
commit (as advised by the vuejs official documentation).