### PR TITLE
webpack config: add support for bootstrap 4 beta 2

### DIFF
--- a/js/webpack_get_defaults.js
+++ b/js/webpack_get_defaults.js
@@ -252,6 +252,11 @@ module.exports = function (basePath) {
       break
   }
 
+  const providePlugin = new webpack.ProvidePlugin({
+    $: 'jquery',
+  })
+  plugins.push(providePlugin)
+
   return {
     cache: true,
     context: basePath,


### PR DESCRIPTION
Bootstrap is dependent on jQuery and Popper, so they must be
provided explicitly by webpack.

This commit includes a new plugin to webpack to fix a
problem related to jQuery and according to the configuration
example provided here:
http://getbootstrap.com/docs/4.0/getting-started/webpack/

The dependency on Popper should be resolved by including
`bootstrap.bundle.js` instead of only `bootstrap.js` in the
project imports.
The bundled version of bootstrap includes popper since this
pull request and should not be a problem in the future.
https://github.com/twbs/bootstrap/pull/23735
  