### PR TITLE
package.json: set minimal eslint version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Changes
 =======
 
+Next version
+--------------
+- Fix eslint-plugin-html dependency on eslint
+
 Version 1.10.0
 --------------
 - Fix a bug with source maps: use inline source maps.

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "cache-loader": "^1.2.0",
     "css-loader": "0.28.9",
     "easygettext": "2.3.0",
+    "eslint": "^4.7.0",
     "eslint-plugin-html": "4.0.2",
     "extract-text-webpack-plugin": "^3.0.2",
     "file-loader": "1.1.6",


### PR DESCRIPTION
This version is required by current eslint-plugin-html version (4.0.2)
See https://github.com/BenoitZugmeyer/eslint-plugin-html#migration-to-v4