### PR TITLE
makefile: Allow to pass arguments to `make test` when using Jest

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -160,7 +160,7 @@ ifeq ($(TEST_ENGINE),karma)
 	karma start --reporters webpack-error --single-run --no-auto-watch $(KARMA_OPTIONS_CONFIG_FILE)
 endif
 ifeq ($(TEST_ENGINE),jest)
-	jest --config=$(JEST_OPTIONS_CONFIG_FILE) --no-cache
+	jest --config=$(JEST_OPTIONS_CONFIG_FILE) --no-cache ${ARGS}
 endif
 
 jenkins-test: prepare syntax


### PR DESCRIPTION
Example:

    make jest ARGS='-t "createTask"'

... to run only tests with a name that matches the pattern.