### PR TITLE
mk.main.mk: Force timezone to UTC for jest tests

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -160,7 +160,7 @@ ifeq ($(TEST_ENGINE),karma)
 	karma start --reporters webpack-error --single-run --no-auto-watch $(KARMA_OPTIONS_CONFIG_FILE)
 endif
 ifeq ($(TEST_ENGINE),jest)
-	jest --config=$(JEST_OPTIONS_CONFIG_FILE) --no-cache ${ARGS}
+	TZ=utc jest --config=$(JEST_OPTIONS_CONFIG_FILE) --no-cache ${ARGS}
 endif
 
 jenkins-test: prepare syntax


### PR DESCRIPTION
    Jenkins use UTC timezone.

====

C'est pénible d'avoir les tests filio (et surement d'autres) qui plantent en local à cause des problèmes de dates.