### PR TITLE
js.babel_jest_transformer: Allow usage of async generator function with jest

### DIFF
--- a/default_config/babelrc
+++ b/default_config/babelrc
@@ -6,7 +6,9 @@
     "test": {
       "plugins": [
         "transform-es2015-modules-commonjs",
-        "dynamic-import-node"
+        "dynamic-import-node",
+        "transform-async-to-generator",
+        "transform-async-generator-functions"
       ],
       "presets": [
         [


### PR DESCRIPTION
    These two transformers let us test with jest without getting  syntax errors on "for await (let i of myAsyncGenerator())"

====

Ce changement nous permet de passer lookcoco sous jest.