### PR TITLE
Rlecellier/fix pug template against vue loader last version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Changes
 =======
 
+Version 2.1.8
+-------------
+- Allow usage of async generator functions with jest test engine.
+
 Version 2.1.7
 -------------
 - Allow using Jest instead of Karma for tests

--- a/js/webpack_get_defaults.js
+++ b/js/webpack_get_defaults.js
@@ -300,6 +300,20 @@ module.exports = function (basePath) {
           use: baseCssLoaders.concat([cssLoader, postCssLoader, sassLoader]),
         },
         { test: /\.jade$/, use: 'jade-loader' },
+        {
+          test: /\.pug$/,
+          oneOf: [
+            // this applies to `<template lang="pug">` in Vue components
+            {
+              resourceQuery: /^\?vue/,
+              use: ['pug-plain-loader'],
+            },
+            // this applies to pug imports inside JavaScript
+            {
+              use: ['raw-loader', 'pug-plain-loader'],
+            },
+          ],
+        },
         { test: /\.html$/, use: 'html-loader' },
         { test: /\.(png|gif|jp(e)?g)$/, use: 'url-loader?limit=50000' },
         { test: /\.(ttf|eot|svg|woff(2)?)(\?v=[0-9]\.[0-9]\.[0-9])?$/, use: 'url-loader?limit=50000' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "systematic",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "postcss-cssnext": "^3.1.0",
     "postcss-import": "^11.1.0",
     "postcss-loader": "^2.1.6",
+    "pug-plain-loader": "^2.4.0",
     "puppeteer": "^1.6.2",
     "sass-loader": "^7.1.0",
     "standard": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systematic",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "main": "./index.js",
   "description": "Simple tooling for frontend apps",
   "publishConfig": {


### PR DESCRIPTION
vue-loader release changelog: https://vue-loader.vuejs.org/migrating.html#template-preprocessing
vue-loader current documentation about preprocessors: https://vue-loader.vuejs.org/guide/pre-processors.html#pug

Ajout du loader pour les fichiers `.pug` et les template vuejs utilisant `lang=pug` cf le message de commit.

