### PR TITLE
Add coverage options to all our tests

### DIFF
--- a/js/jest_get_defaults.js
+++ b/js/jest_get_defaults.js
@@ -3,11 +3,18 @@
 
 'use strict'
 
+const path = require('path')
+
 const systematicConfig = require('./config')
 const babelDefaults = require('./babel_get_defaults.js')()
 
 module.exports = function (basePath) {
+  basePath = path.normalize(basePath)
   return {
+    collectCoverageFrom: [
+      '{src,lib}/**/*.{js,jsx,vue}',
+    ],
+    coveragePathIgnorePatterns: ['/node_modules/', 'spec.js', 'test.js'],
     moduleFileExtensions: [
       'js',
       'json',
@@ -27,9 +34,7 @@ module.exports = function (basePath) {
     moduleNameMapper: {
       '\\.(css|less)$': 'identity-obj-proxy',
     },
-    roots: [
-      basePath,
-    ],
+    rootDir: basePath,
     setupTestFrameworkScriptFile: systematicConfig.test.setup_script_file,
     testRegex: systematicConfig.test.file_pattern,
     globals: {

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -168,7 +168,7 @@ ifeq ($(TEST_ENGINE),karma)
 	karma start --reporters junit,webpack-error --single-run --no-auto-watch --no-colors $(KARMA_OPTIONS_CONFIG_FILE)
 endif
 ifeq ($(TEST_ENGINE),jest)
-	JEST_JUNIT_OUTPUT='./reports/TEST-jest.xml' JEST_JUNIT_CLASSNAME="{classname}" JEST_JUNIT_TITLE="{title}" jest --ci --reporters=default --reporters=jest-junit --config=$(JEST_OPTIONS_CONFIG_FILE) --no-cache
+	JEST_JUNIT_OUTPUT='./reports/TEST-jest.xml' JEST_JUNIT_CLASSNAME="{classname}" JEST_JUNIT_TITLE="{title}" jest --ci --coverage --reporters=default --reporters=jest-junit --config=$(JEST_OPTIONS_CONFIG_FILE) --no-cache
 endif
 
 livetest: prepare


### PR DESCRIPTION
```shell
(palettone) [vperron@M]<~/dev/palettone-ui> make jenkins-test
eslint --config ./node_modules/systematic/.eslintrc --ext .js,.vue --plugin html src
JEST_JUNIT_OUTPUT='./reports/TEST-jest.xml' JEST_JUNIT_CLASSNAME="{classname}" JEST_JUNIT_TITLE="{title}" jest --ci --coverage --reporters=default --reporters=jest-junit --config=node_modules/systematic/default_config/jest.conf.js --no-cac
he             
 PASS  src/pages/app.spec.js
  App
    ✓ should export "App" (4ms)
  Overview                                                              
    ✓ should export "Overview"
 
--------------------|----------|----------|----------|----------|-------------------|
File                |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
--------------------|----------|----------|----------|----------|-------------------|
All files           |     4.76 |        0 |        0 |     4.76 |                   |
 src                |        0 |        0 |        0 |        0 |                   |
  api.js            |        0 |      100 |        0 |        0 |... 38,40,46,47,48 |
  auth.js           |        0 |        0 |      100 |        0 |   3,4,6,8,9,14,19 |
  index.js          |        0 |        0 |        0 |        0 |... 63,66,67,70,71 |
  router.js         |        0 |      100 |      100 |        0 |       1,2,4,5,7,9 |
 src/components     |    28.57 |      100 |        0 |    28.57 |                   |
  LeafletMap.vue    |    28.57 |      100 |        0 |    28.57 |    14,15,21,25,26 |
 src/pages          |      100 |      100 |      100 |      100 |                   |
  overview.vue      |      100 |      100 |      100 |      100 |                   |
 src/store          |        0 |      100 |      100 |        0 |                   |
  index.js          |        0 |      100 |      100 |        0 |... ,8,10,16,21,22 |
  mutation-types.js |        0 |      100 |      100 |        0 |                 1 |
--------------------|----------|----------|----------|----------|-------------------|
Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        5.681s
Ran all test suites.                
```